### PR TITLE
Fix / a mail not have encode infomation, AttributeError occurred.

### DIFF
--- a/kite_mail/mail.py
+++ b/kite_mail/mail.py
@@ -18,7 +18,10 @@ class kiteMail(object):
     def _get_content_encode(self):
         header_content_type = self.factory.get_decoded_header('content-type')
         _result = re.search(r'charset=(\S+)', header_content_type)
-        return _result.group(1).lower()
+        if _result:
+            return _result.group(1).lower()
+        else:
+            return None
 
     def get_mailpart(self):
 
@@ -29,7 +32,7 @@ class kiteMail(object):
         elif msg.text_html:
             _result = msg.html_part.get_payload()
 
-        if not self.content_encode== None:
+        if self.content_encode:
             return _result.decode(self.content_encode)
 
         return _result


### PR DESCRIPTION
Bug fix

```
Traceback (most recent call last):
  File "/home/laughk/work/kite-mail/venv/bin/kite-mail", line 9, in <module>
    load_entry_point('kite-mail==0.0.0.dev0', 'console_scripts', 'kite-mail')()
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/laughk/work/kite-mail/kite_mail/cli.py", line 25, in main
    kite_mail = kiteMail(RAW_MAIL)
  File "/home/laughk/work/kite-mail/kite_mail/mail.py", line 13, in __init__
    self.content_encode = self._get_content_encode()
  File "/home/laughk/work/kite-mail/kite_mail/mail.py", line 21, in _get_content_encode
    return _result.group(1).lower()
AttributeError: 'NoneType' object has no attribute 'group'
```
