### PR TITLE
Add options, to control Mail from, Mail subject, Mail body part.

### DIFF
--- a/kite_mail/cli.py
+++ b/kite_mail/cli.py
@@ -8,16 +8,35 @@ from kite_mail.utils import help_messages
 
 @click.command(context_settings={'help_option_names' : ['-h', '--help']})
 @click.argument('takosan_url', nargs=1, required=True)
+@click.option('--name', nargs=1, default='Mail Notify',
+        help=help_messages('name'))
 @click.option('--channel', 'channels',
         nargs=1, required=True, multiple=True,
         help=help_messages('channel'))
-@click.option('--name', nargs=1, default='Mail Notify',
-        help=help_messages('name'))
 @click.option('--icon', nargs=1, default=':mailbox_with_mail:',
         help=help_messages('icon'))
 @click.option('--body/--no-body', default=False,
         help=help_messages('body'))
-def main(takosan_url, channels, name, icon, body):
+@click.option('--body-color', nargs=1,
+        help=help_messages('color'))
+@click.option('--body-prefix', nargs=1, default=':memo:',
+        help=help_messages('body_prefix'))
+@click.option('--subject-prefix', nargs=1, default=':round_pushpin:',
+        help=help_messages('subject_prefix'))
+@click.option('--from/--no-from', 'is_mail_from', default=False,
+        help=help_messages('from'))
+@click.option('--from-prefix', nargs=1, default=':black_nib:',
+        help=help_messages('from_prefix'))
+def main(takosan_url,
+        channels,
+        name,
+        icon,
+        body,
+        body_color,
+        body_prefix,
+        subject_prefix,
+        is_mail_from,
+        from_prefix):
 
     RAW_MAIL = click.get_text_stream('stdin')
     kite_mail = kiteMail(RAW_MAIL)
@@ -26,12 +45,14 @@ def main(takosan_url, channels, name, icon, body):
     notify_payload = {
         'name'    : name,
         'icon'    : icon,
-        'message' : u':round_pushpin: *{0}*'.format(factory.get_subject()),
-        'pretext' : u':black_nib: From: {0[0]} {0[1]}'.format(factory.get_address('from')),
+        'color'   : body_color,
+        'message' : u'{0} *{1}*'.format(subject_prefix, factory.get_subject()),
     }
 
     if body:
-        notify_payload['text'] = kite_mail.get_mailpart()
+        notify_payload['text'] = '{0} {1}'.format(body_prefix, kite_mail.get_mailpart())
+    if is_mail_from:
+        notify_payload['pretext'] = u'{0} From: {1[0]} {1[1]}'.format(from_prefix, factory.get_address('from'))
 
     kite = Tako(takosan_url, channels, notify_payload)
     kite.flying()

--- a/kite_mail/utils.py
+++ b/kite_mail/utils.py
@@ -11,10 +11,23 @@ def help_messages(command):
         'icon':
             'set image url or emoji (e.g. :shachikun:)',
         'body':
-            'the flag decide include mail body part. (Default: False) '
+            'the flag decide include mail body part. (Default: False) ',
+        'body_prefix':
+            'add prefix text message for mail body part. (Default: ":memo:" )',
+        'subject_prefix':
+            'add prefix text message for mail subject. (Default: ":round_pushpin:" )',
+        'from':
+            'the flag decide include mail from part. (Default: False) ',
+        'from_prefix':
+            'add prefix text message for mail from part. (Default: ":black_nib:" )',
+        'color':
+            'set color border along the left side of the message attachment [good|warning|danger|<hex color code>]  (e.g. #439FE0)',
     }
 
     if msg[command] :
         return msg[command]
     else:
         return None
+
+def version():
+    return '0.0.1.dev0'

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@
 # -*- coding:utf-8 -*-
 
 from setuptools import setup, find_packages
+from kite_mail import utils
 
 setup(
 
     name='kite-mail',
     description='kite-mail is a command-line tool to request the contents of e-mail to takosan .',
-    version='0.0.0.dev0',
+    version=utils.version(),
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
this PR add this options,

```
  --body-color TEXT      set color border along the left side of the message
                         attachment [good|warning|danger|<hex color code>]
                         (e.g. #439FE0)
  --body-prefix TEXT     add prefix text message for mail body part. (Default:
                         ":memo:" )
  --subject-prefix TEXT  add prefix text message for mail subject. (Default:
                         ":round_pushpin:" )
  --from / --no-from     the flag decide include mail from part. (Default:
                         False)
  --from-prefix TEXT     add prefix text message for mail from part. (Default:
                         ":black_nib:" )
```
