### PR TITLE
Fix unicode encode error no encoding data mail

### DIFF
--- a/kite_mail/cli.py
+++ b/kite_mail/cli.py
@@ -50,7 +50,7 @@ def main(takosan_url,
     }
 
     if body:
-        notify_payload['text'] = '{0} {1}'.format(body_prefix, kite_mail.get_mailpart())
+        notify_payload['text'] = u'{0} {1}'.format(body_prefix, kite_mail.get_mailpart())
     if is_mail_from:
         notify_payload['pretext'] = u'{0} From: {1[0]} {1[1]}'.format(from_prefix, factory.get_address('from'))
 

--- a/kite_mail/mail.py
+++ b/kite_mail/mail.py
@@ -34,7 +34,7 @@ class kiteMail(object):
 
         if self.content_encode:
             return _result.decode(self.content_encode)
-
-        return _result
+        else:
+            return _result.decode('utf-8')
 
 


### PR DESCRIPTION
this PR fix this bug.

if a mail have encoding data, this UnicodeEncodeError occurred...

```
Traceback (most recent call last):
  File "/home/laughk/work/kite-mail/venv/bin/kite-mail", line 9, in <module>
    load_entry_point('kite-mail==0.0.0.dev0', 'console_scripts', 'kite-mail')()
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/laughk/work/kite-mail/venv/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/laughk/work/kite-mail/kite_mail/cli.py", line 53, in main
    notify_payload['text'] = '{0} {1}'.format(body_prefix, kite_mail.get_mailpart())
UnicodeEncodeError: 'ascii' codec can't encode characters in position 20-24: ordinal not in range(128)
```
